### PR TITLE
Fix for localized dates (month names with unicode)

### DIFF
--- a/CRM/Logviewer/Page/LogViewer.php
+++ b/CRM/Logviewer/Page/LogViewer.php
@@ -16,8 +16,9 @@ class CRM_Logviewer_Page_LogViewer extends CRM_Core_Page {
         $line++;
         $dd = fgets($handle);
         if (strlen($dd) >= 15 && (' ' != $dd[0])) {
-          $date = substr($dd,0,15);
-          if (preg_match("/^[A-Za-z]{3} [0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/",$date)) {
+          // Also support localized dates such as: "fév 14 12:51:13"
+          $date = mb_substr($dd,0,15);
+          if (preg_match("/^\w{3} [0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/u",$date)) {
             $entry_url = CRM_Utils_System::url('civicrm/admin/logviewer/logentry', $query = 'lineNumber='.$line);
             $entries[$line] = array('lineNumber' => '<a href="'.$entry_url.'">'.$line.'</a>', 'dateTime' => $date, 'message' => substr($dd,16));
           }


### PR DESCRIPTION
A partner noticed that the log was empty and thought it was a file permission issue, because when there are no entries, logviewer displays "Unable to read entries from logfile at ..".

The bug was instead that logviewer has a regexp for detecting dates, but the site's default language is in French, so the logs have entries such as `fév 14 12:51:13`.

To reproduce:

* Delete logs from ConfigAndLog
* Set the CiviCRM default language to French, while in the month of February (février)
* Do things while the UI is in French, so that CiviCRM logs deprecation warnings in the log, or do something that will cause a random fatal, such as `https://crm.example.org/civicrm/participant/add?reset=1`
* Go to logviewer

This PR makes sure that unicode is used in the relevant string functions.