### PR TITLE
sanitize output to fix XSS vulnerability

### DIFF
--- a/CRM/Logviewer/Page/LogViewEntry.php
+++ b/CRM/Logviewer/Page/LogViewEntry.php
@@ -56,6 +56,8 @@ class CRM_Logviewer_Page_LogViewEntry extends CRM_Core_Page {
       $next_url = CRM_Utils_System::url('civicrm/admin/logviewer/logentry', $query = 'lineNumber='.$nextLine);
       $next_a = '<a class="button" href="'.$next_url.'"><span><i class="crm-i fa-chevron-right" aria-hidden="true"></i> ' . E::ts('Next') . '</span></a>';
     }
+    $entry = htmlentities($entry, ENT_QUOTES, 'UTF-8');
+    
     $this->assign('prevURL', $prev_a);
     $this->assign('nextURL', $next_a);
     $this->assign('logEntry', $entry);


### PR DESCRIPTION
sanitize output to fix XSS vulnerability - Specifically issue #11 

POC - 
Example of injecting window.location to navigate the administrator from the admin console - Possibilities are endless for this. In this case, I specified my GitHub profile. 

(Ignore the errors - Local dev site used for example). 
![xss_vulnerability](https://user-images.githubusercontent.com/95014899/233451631-a82a3350-f00e-479a-8160-079caa9a91b9.gif)

<img width="914" alt="image" src="https://user-images.githubusercontent.com/95014899/233452125-bfe09f10-c8f2-4b64-bb41-017db76a78c7.png">

Fix:
Simple addition of [htmlentities](https://www.php.net/manual/en/function.htmlentities.php) on the $entry. 

