### PR TITLE
Support download of log file

### DIFF
--- a/CRM/Logviewer/Page/LogDownload.php
+++ b/CRM/Logviewer/Page/LogDownload.php
@@ -1,0 +1,20 @@
+<?php
+
+class CRM_Logviewer_Page_LogDownload extends CRM_Core_Page {
+
+  public function run() {
+    $file_log = CRM_Core_Error::createDebugLogger();
+    $logFileName = $file_log->_filename;
+    $file_log->close();
+
+    //Mark as a plain-text file.
+    CRM_Utils_System::setHttpHeader('Content-Type', 'text/plain');
+
+    //Download the file with its name.
+    CRM_Utils_System::setHttpHeader('Content-Disposition', 'attachment; filename=' . basename($logFileName));
+    readfile($logFileName);
+    CRM_Utils_System::civiExit();
+
+  }
+
+}

--- a/templates/CRM/Logviewer/Page/LogViewer.tpl
+++ b/templates/CRM/Logviewer/Page/LogViewer.tpl
@@ -1,4 +1,5 @@
 {crmButton p='civicrm/admin/logviewer' q='reset=1' icon='refresh'}{ts}Refresh{/ts}{/crmButton}
+{crmButton p='civicrm/admin/logviewer/download' q='reset=1' icon='download'}{ts}Download Log File{/ts}{/crmButton}
 
 <p>{ts 1=$currentTime}The current time is %1.{/ts}</p>
 

--- a/xml/Menu/logviewer.xml
+++ b/xml/Menu/logviewer.xml
@@ -7,6 +7,12 @@
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
   <item>
+    <path>civicrm/admin/logviewer/download</path>
+    <page_callback>CRM_Logviewer_Page_LogDownload</page_callback>
+    <title>Log Viewer: Download</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
+  <item>
     <path>civicrm/admin/logviewer/logentry</path>
     <page_callback>CRM_Logviewer_Page_LogViewEntry</page_callback>
     <title>Log Entry View</title>


### PR DESCRIPTION
Large log files can be difficult to read in the browser. A downloaded log file can be parsed, searched, etc, with familiar tools for easier examination. I'd love to have this feature and hope this PR makes it easier to for that to happen.