### PR TITLE
pear log 1.14 compatibility

### DIFF
--- a/CRM/Logviewer/Page/LogDownload.php
+++ b/CRM/Logviewer/Page/LogDownload.php
@@ -4,7 +4,7 @@ class CRM_Logviewer_Page_LogDownload extends CRM_Core_Page {
 
   public function run() {
     $file_log = CRM_Core_Error::createDebugLogger();
-    $logFileName = $file_log->_filename;
+    $logFileName = CRM_Core_Error::generateLogFileName('');
     $file_log->close();
 
     //Mark as a plain-text file.

--- a/CRM/Logviewer/Page/LogViewEntry.php
+++ b/CRM/Logviewer/Page/LogViewEntry.php
@@ -9,8 +9,7 @@ class CRM_Logviewer_Page_LogViewEntry extends CRM_Core_Page {
     CRM_Core_Resources::singleton()->addScriptUrl('//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js', 10, 'page-header');
     CRM_Core_Resources::singleton()->addStyleUrl('//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/default.min.css');
     $file_log = CRM_Core_Error::createDebugLogger();
-    $logFileName = $file_log->_filename;
-    $logFileFormat = $file_log->_lineFormat;
+    $logFileName = CRM_Core_Error::generateLogFileName('');
     $file_log->close();
     $this->assign('fileName', $logFileName);
     $handle = fopen($logFileName,'r') or die ('File opening failed');

--- a/CRM/Logviewer/Page/LogViewer.php
+++ b/CRM/Logviewer/Page/LogViewer.php
@@ -5,7 +5,7 @@ class CRM_Logviewer_Page_LogViewer extends CRM_Core_Page {
   public function run() {
     $this->assign('currentTime', date('Y-m-d H:i:s'));
     $file_log = CRM_Core_Error::createDebugLogger();
-    $logFileName = $file_log->_filename;
+    $logFileName = CRM_Core_Error::generateLogFileName('');
     $file_log->close();
     $this->assign('fileName', $logFileName);
     $entries = [];

--- a/info.xml
+++ b/info.xml
@@ -17,7 +17,7 @@
   <version>2.1.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.67</ver>
+    <ver>5.76</ver>
   </compatibility>
   <comments>View the most recent CiviCRM debug logfile, useful for quick access to recent errors or warnings.  The log is accessed via the menu entry 'Administer &gt; Administration Console &gt; View Log'.</comments>
   <civix>


### PR DESCRIPTION
In civi 5.76, it switches to pear/log 1.14 which no longer has any way to get the filename. But in 5.76 core now provides its own public function to do it.

Since the version of pear/log is fixed exactly in core, there is a hard cut between 5.75 and 5.76, regardless of cms, so I've proposed upping the minimum install version to 5.76, which sounds weird at first but since the new function isn't available until 5.76, it would fail on <5.76.

An alternative is support both if it was desired to have any new upcoming features available to <5.76.