### PR TITLE
Escape message in log view list

### DIFF
--- a/templates/CRM/Logviewer/Page/LogViewer.tpl
+++ b/templates/CRM/Logviewer/Page/LogViewer.tpl
@@ -42,7 +42,7 @@
           <td>{$row.lineNumber}</td>
           <td>{$row.severity}</td>
           <td>{$row.dateTime}</td>
-          <td>{$row.message}</td>
+          <td>{$row.message|escape}</td>
           <td></td>
         </tr>
       {/foreach}


### PR DESCRIPTION
### Overview
Escape log message text in log list view.

### Before
If a log entry contains unescaped HTML or even worse JavaScript like
``` html
<script>window.location='http://attacker.example.com/'</script>
```
and we list it in log list view, than the HTML would be rendered and the JavaScript would be executed - in the given example the page would be redirected to attacker.example.com.

### After
The log list view would just shows the (escaped) HTML/JavaScript.

### Technical Details
Showing a single log entry we are escaping in LogViewEntry.php:
``` php
  $entry = htmlentities($entry, ENT_QUOTES, 'UTF-8');
```
but we do not in the list view.
So the example above would redirect the browser to the given page.
This can be prevented in the template:
``` diff
-           <td>{$row.message}</td>
+           <td>{$row.message|escape}</td>
```
or in the class file:
``` diff
-                'message' => $msg,
+                'message' => htmlentities($msg, ENT_QUOTES, 'UTF-8'),
```

I decided to do it in the template.

### Comment
I stumbled upon this while testing user input data with potentially malicious HTML/JavaScript.
Debugging I wrote some stuff in the Civi log file *including the above mentioned JavaScript*. Looking at the logviewer list view I was redirected - so I took a closer look.